### PR TITLE
Fix not all blogpost have been shown

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ enableEmoji: true
 menu:
   main:
     - name: Blog
-      url: /
+      url: /blog/
       weight: -1
     - name: About
       url: /about/

--- a/themes/reaktor23/layouts/blog/list.html
+++ b/themes/reaktor23/layouts/blog/list.html
@@ -1,0 +1,7 @@
+{{ define "main" }}
+<div class="list-group">
+{{ range .Data.Pages }}
+<a class="list-group-item list-group-item-action" href="{{ .Permalink }}">{{ .Title }}<small class="text-muted mx-2">by {{ .Params.Author }} - {{ .Date.Format "2006-01-02" }}</small></a>
+{{ end }}
+</div>
+{{ end }}

--- a/themes/reaktor23/layouts/index.html
+++ b/themes/reaktor23/layouts/index.html
@@ -1,8 +1,5 @@
 {{ define "main" }}
 {{- range $i, $e := (first 5 (where $.Site.RegularPages "Section" "blog")) }}
-{{- if gt $i 0 }}
-<hr>
-{{- end }}
 <article>
     <header>
         <h1 class="headline"><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
@@ -19,5 +16,12 @@
     </header>
     {{ .Content }}
 </article>
+
+<hr>
 {{- end }}
+
+<div class="d-flex justify-content-center mt-5">
+    <a class="btn btn-outline-secondary" href="/blog/">more</a>
+</div>
+
 {{ end }}


### PR DESCRIPTION
Also, there was not list to all blog posts linked someswhere.

Now, https://reaktor23.org/ shows the full last 5 blog posts and
https://reaktor23.org/blog/ the overview over all blog posts.