### PR TITLE
Deploy to gh-pages using repo scope token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,14 +26,8 @@ jobs:
         run: |
           hugo -v --cleanDestinationDir --baseURL="https://reaktor23.org"
 
-      - name: Install SSH Client 🔑
-        uses: webfactory/ssh-agent@v0.4.1
-        with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
-
       - name: Deploy to gh-pages 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
-          SSH: true
-          BRANCH: gh-pages
-          FOLDER: public
+          branch: gh-pages
+          folder: public


### PR DESCRIPTION
There is no need to use SSH and SSH keys. Each repo has an repo scope
token which can be used. This is the default for the
JamesIves/github-pages-deploy-action.