### PR TITLE
Hide Github corner icon on small devices

### DIFF
--- a/themes/reaktor23/layouts/partials/github-corner.html
+++ b/themes/reaktor23/layouts/partials/github-corner.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/reaktor23/website" class="github-corner" aria-label="View source on Github">
+<a href="https://github.com/reaktor23/website" class="github-corner d-none d-sm-block" aria-label="View source on Github">
   <svg width="80" height="80" viewBox="0 0 250 250" style="fill: #46b71d; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
     <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
     <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>


### PR DESCRIPTION
so it doesn't interfere with the menu button